### PR TITLE
Add BaFin brand colors

### DIFF
--- a/brands/bafin.json
+++ b/brands/bafin.json
@@ -6,7 +6,7 @@
     "3b2e80"
   ],
   "brandUrl": "https://www.bafin.de/",
-  "sourceUrl": "https://www.designtagebuch.de/bundesanstalt-fuer-finanzdienstleistungsaufsicht-bafin-fuehrt-neues-corporate-design-ein/bafin-farben/",
+  "sourceUrl": "https://www.bafin.de/SharedDocs/Veroeffentlichungen/EN/Fachartikel/2026/fa_bj_260409_bafin_neue_website_en.html",
   "category": "Government",
   "description": "The Bundesanstalt für Finanzdienstleistungsaufsicht (BaFin) is Germany's federal financial supervisory authority. Its corporate design features a deep green (#15423f) as the primary brand color, complemented by a warm gold tone (#b79b5a) and a rich purple (#3b2e80), reflecting the authority's modern and trustworthy visual identity."
 }

--- a/brands/bafin.json
+++ b/brands/bafin.json
@@ -1,0 +1,12 @@
+{
+  "title": "Bundesanstalt für Finanzdienstleistungsaufsicht (BaFin)",
+  "colors": [
+    "15423f",
+    "b79b5a",
+    "3b2e80"
+  ],
+  "brandUrl": "https://www.bafin.de/",
+  "sourceUrl": "https://www.designtagebuch.de/bundesanstalt-fuer-finanzdienstleistungsaufsicht-bafin-fuehrt-neues-corporate-design-ein/bafin-farben/",
+  "category": "Government",
+  "description": "The Bundesanstalt für Finanzdienstleistungsaufsicht (BaFin) is Germany's federal financial supervisory authority. Its corporate design features a deep green (#15423f) as the primary brand color, complemented by a warm gold tone (#b79b5a) and a rich purple (#3b2e80), reflecting the authority's modern and trustworthy visual identity."
+}


### PR DESCRIPTION
## Summary
- Adds brand entry for Bundesanstalt für Finanzdienstleistungsaufsicht (BaFin), Germany's federal financial supervisory authority
- Includes primary colors: deep green (#15423f), gold (#b79b5a), and purple (#3b2e80)
- Category: Government

## Source
Colors sourced from the published BaFin corporate design documentation referenced at designtagebuch.de.

https://claude.ai/code/session_01XSLzPi5W16oE6QQgCx2hjb