### PR TITLE
Add Peach Aviation brand colors

### DIFF
--- a/brands/peach-aviation.json
+++ b/brands/peach-aviation.json
@@ -1,0 +1,13 @@
+{
+  "title": "Peach Aviation",
+  "slug": "peach-aviation",
+  "colors": [
+    "c39378",
+    "fff9f2",
+    "ef8ea5"
+  ],
+  "brandUrl": "https://www.flypeach.com/",
+  "sourceUrl": "https://www.flypeach.com/information/brand/en/",
+  "category": "Airline",
+  "description": "Peach Aviation is a Japanese low-cost airline headquartered in Osaka. Following its 2024 rebranding, the airline adopted a softer, more refined palette anchored by a warm beige-brown (#c39378) and a creamy off-white (#fff9f2), accented by its signature peach pink (#ef8ea5). The updated identity is documented on Peach's official brand page."
+}


### PR DESCRIPTION
## Summary
- Adds `brands/peach-aviation.json` with Peach Aviation's updated brand palette (#c39378, #fff9f2, #ef8ea5) reflecting the 2024 rebrand.
- `sourceUrl` points to the official Peach brand page: https://www.flypeach.com/information/brand/en/
- `brandUrl` set to https://www.flypeach.com/, category "Airline".

## Test plan
- [ ] Schema validation passes for the new JSON entry.
- [ ] Colors render correctly on the site.
