### PR TITLE
Add social media and messaging brand colors

### DIFF
--- a/brands/douyin.json
+++ b/brands/douyin.json
@@ -1,0 +1,13 @@
+{
+  "title": "Douyin",
+  "colors": [
+    "000000",
+    "FE2C55",
+    "25F4EE",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://www.douyin.com/",
+  "sourceUrl": null,
+  "category": "Social Media",
+  "description": "Douyin is ByteDance's Chinese short-video platform and the sibling app to TikTok. It shares the same visual identity built around a black (#000000) core set against a vivid red/pink (#FE2C55) and cyan (#25F4EE), with white (#FFFFFF) used for contrast. These colors appear consistently in the Douyin logo, app interface, and official communications."
+}

--- a/brands/imo.json
+++ b/brands/imo.json
@@ -1,0 +1,11 @@
+{
+  "title": "imo",
+  "colors": [
+    "1BB6EC",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://imo.im/",
+  "sourceUrl": null,
+  "category": "Communication Technology",
+  "description": "imo is a free video calling and instant messaging application developed by Pagebites. Its brand is centered on a bright sky blue (#1BB6EC), paired with white (#FFFFFF) for a friendly, approachable look. These colors appear in the imo app icon, logo, and user interface across mobile and desktop."
+}

--- a/brands/josh.json
+++ b/brands/josh.json
@@ -1,0 +1,12 @@
+{
+  "title": "Josh",
+  "colors": [
+    "F0286F",
+    "000000",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://myjosh.in/",
+  "sourceUrl": null,
+  "category": "Social Media",
+  "description": "Josh is an Indian short-form video platform developed by VerSe Innovation, launched to serve a multilingual domestic audience. Its brand identity is anchored by a vivid pink-magenta (#F0286F), complemented by black (#000000) and white (#FFFFFF). These colors are reflected in the Josh logo, app interface, and promotional materials."
+}

--- a/brands/kuaishou.json
+++ b/brands/kuaishou.json
@@ -1,0 +1,12 @@
+{
+  "title": "Kuaishou",
+  "colors": [
+    "FF6600",
+    "000000",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://www.kuaishou.com/",
+  "sourceUrl": null,
+  "category": "Social Media",
+  "description": "Kuaishou is a major Chinese short-video and live-streaming platform known for its bold orange logo. The brand is centered on a vibrant orange (#FF6600) that conveys enthusiasm and energy, paired with black (#000000) and white (#FFFFFF) for balance. These colors are consistently used in Kuaishou's square emblem and across its product interface."
+}

--- a/brands/likee.json
+++ b/brands/likee.json
@@ -1,0 +1,12 @@
+{
+  "title": "Likee",
+  "colors": [
+    "FF5C8D",
+    "000000",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://likee.video/",
+  "sourceUrl": null,
+  "category": "Social Media",
+  "description": "Likee is a global short-form video platform developed by BIGO Technology, a subsidiary of JOYY. Following its brand refresh, Likee's identity is infused with a warm pink-red tone (#FF5C8D), complemented by black (#000000) and white (#FFFFFF). This palette is used across the Likee logo, app, and promotional content."
+}

--- a/brands/picsart.json
+++ b/brands/picsart.json
@@ -1,0 +1,12 @@
+{
+  "title": "Picsart",
+  "colors": [
+    "C209C1",
+    "FFFFFF",
+    "000000"
+  ],
+  "brandUrl": "https://picsart.com/",
+  "sourceUrl": null,
+  "category": "Photo and Video Editing",
+  "description": "Picsart is a popular photo and video editing platform known for its creative, community-driven tools. The brand's visual identity is led by a bold magenta-purple (#C209C1), supported by black (#000000) and white (#FFFFFF) for strong contrast. These colors feature prominently in the Picsart logo, app icon, and marketing materials."
+}

--- a/brands/qq.json
+++ b/brands/qq.json
@@ -1,0 +1,14 @@
+{
+  "title": "QQ",
+  "colors": [
+    "12B7F5",
+    "FEBF1B",
+    "E32B10",
+    "121214",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://im.qq.com/",
+  "sourceUrl": null,
+  "category": "Communication Technology",
+  "description": "QQ is Tencent's long-running instant messaging service, famous for its penguin mascot. The brand palette pairs a bright sky blue (#12B7F5) with a warm yellow (#FEBF1B) and red scarf accent (#E32B10), supported by near-black (#121214) and white (#FFFFFF). These colors define QQ's mascot, logo, and product identity."
+}

--- a/brands/qzone.json
+++ b/brands/qzone.json
@@ -1,0 +1,12 @@
+{
+  "title": "Qzone",
+  "colors": [
+    "FECE00",
+    "000000",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://qzone.qq.com/",
+  "sourceUrl": null,
+  "category": "Social Media",
+  "description": "Qzone is Tencent's personal social networking service, historically tied to QQ and recognized by its bright yellow star logo. The brand palette centers on a warm yellow (#FECE00), complemented by black (#000000) and white (#FFFFFF) for clarity and contrast. These colors are featured prominently in Qzone's iconography and app presence."
+}

--- a/brands/teams.json
+++ b/brands/teams.json
@@ -1,0 +1,14 @@
+{
+  "title": "Microsoft Teams",
+  "colors": [
+    "6264A7",
+    "464EB8",
+    "7B83EB",
+    "505AC9",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://www.microsoft.com/microsoft-teams/",
+  "sourceUrl": null,
+  "category": "Communication Technology",
+  "description": "Microsoft Teams is Microsoft's collaboration and communications hub for chat, meetings, and calls. Its brand is built on a distinctive purple-blue palette anchored by #6264A7, with deeper (#464EB8, #505AC9) and lighter (#7B83EB) companion hues, set against white (#FFFFFF). These tones are featured in the Teams logo, iconography, and product surfaces."
+}

--- a/brands/telegram.json
+++ b/brands/telegram.json
@@ -6,7 +6,7 @@
     "A19679"
   ],
   "brandUrl": "http://telegram.org/",
-  "sourceUrl": "https://brandfetch.com/telegram.org?view=library&library=default&collection=colors",
+  "sourceUrl": null,
   "category": "Communication Technology",
   "description": "The brand 'Telegram' is characterized by a palette of vibrant and complementary colors: a bold sky blue (#0088CC), a clean and vivid white (#FFFFFF), and a subtle warm beige (#A19679). These colors reflect the brand's modern and friendly interface. Official sources detailing these colors can be found on the brand URL and cited on the source URL, ensuring authenticity and adherence to the brand's visual identity."
 }

--- a/brands/threads.json
+++ b/brands/threads.json
@@ -1,0 +1,11 @@
+{
+  "title": "Threads",
+  "colors": [
+    "000000",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://www.threads.net/",
+  "sourceUrl": "https://www.meta.com/brand/resources/instagram/threads/",
+  "category": "Social Media",
+  "description": "Threads is Meta's text-based conversation app launched by Instagram in 2023. The brand embraces a stark monochrome identity built on black (#000000) and white (#FFFFFF), with the app's looping '@' glyph set in a high-contrast color pairing. Meta's official brand guidelines direct usage of only the approved black or white versions on solid backgrounds."
+}

--- a/brands/tieba.json
+++ b/brands/tieba.json
@@ -1,0 +1,11 @@
+{
+  "title": "Baidu Tieba",
+  "colors": [
+    "2529D8",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://tieba.baidu.com/",
+  "sourceUrl": null,
+  "category": "Social Media",
+  "description": "Baidu Tieba is a large Chinese online community and discussion forum operated by Baidu. Its brand identity is built around a deep palatinate blue (#2529D8) that ties it to Baidu's wider design language, paired with white (#FFFFFF) for a clean, readable look. These colors feature in the Tieba logo and app interface."
+}

--- a/brands/tiktok.json
+++ b/brands/tiktok.json
@@ -1,0 +1,13 @@
+{
+  "title": "TikTok",
+  "colors": [
+    "010101",
+    "25F4EE",
+    "FE2C55",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://www.tiktok.com/",
+  "sourceUrl": null,
+  "category": "Social Media",
+  "description": "TikTok is a leading short-form video sharing platform, instantly recognizable by its bold brand palette. The logo pairs a deep black (#010101) base with a vibrant cyan (#25F4EE) and a bright red/pink (#FE2C55), accented with white (#FFFFFF). This striking combination is central to TikTok's youthful, energetic identity across its app, marketing, and social presence."
+}

--- a/brands/vevo.json
+++ b/brands/vevo.json
@@ -1,0 +1,11 @@
+{
+  "title": "Vevo",
+  "colors": [
+    "000000",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://www.vevo.com/",
+  "sourceUrl": "https://brand.vevo.com/color/",
+  "category": "Entertainment",
+  "description": "Vevo is a leading music video network and premier destination for music video content. According to Vevo's official brand guidelines, the core identity is built on a classic black (#000000) and white (#FFFFFF) foundation, accented by a vivid spectrum that includes Blueberry, Pink Flamingo, Red Orange and Cyber Yellow. The monochrome foundation is the primary expression of the Vevo logo."
+}

--- a/brands/weibo.json
+++ b/brands/weibo.json
@@ -1,0 +1,12 @@
+{
+  "title": "Weibo",
+  "colors": [
+    "E6162D",
+    "FA3C2E",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://weibo.com/",
+  "sourceUrl": null,
+  "category": "Social Media",
+  "description": "Sina Weibo is one of China's largest microblogging social networks, recognized by its red eye-shaped logo. The brand palette is anchored by a bold red (#E6162D) and a warmer red-orange (#FA3C2E), paired with white (#FFFFFF) for contrast. These tones feature prominently on Weibo's logo, app, and marketing materials."
+}

--- a/brands/x.json
+++ b/brands/x.json
@@ -1,0 +1,11 @@
+{
+  "title": "X",
+  "colors": [
+    "000000",
+    "FFFFFF"
+  ],
+  "brandUrl": "https://x.com/",
+  "sourceUrl": null,
+  "category": "Social Media",
+  "description": "X, the social network formerly known as Twitter, rebranded in 2023 with a minimalist monochrome identity. The brand is defined by a simple pairing of black (#000000) and white (#FFFFFF), reflected in its stylized 'X' logo and product interface. This stark contrast is used consistently across the platform, app icon, and marketing."
+}

--- a/brands/xiaohongshu.json
+++ b/brands/xiaohongshu.json
@@ -1,0 +1,12 @@
+{
+  "title": "Xiaohongshu",
+  "colors": [
+    "FF2442",
+    "FFFFFF",
+    "000000"
+  ],
+  "brandUrl": "https://www.xiaohongshu.com/",
+  "sourceUrl": null,
+  "category": "Social Media",
+  "description": "Xiaohongshu, also known internationally as RED or RedNote, is a Chinese lifestyle and social commerce platform whose name translates to 'Little Red Book'. True to its name, the brand centers on a vibrant torch red (#FF2442), paired with white (#FFFFFF) and black (#000000) for contrast. These colors appear across the app's logo, interface, and marketing."
+}


### PR DESCRIPTION
## Summary

Adds brand color entries for 16 social media, messaging, and short-video platforms that were missing from the dataset, and fixes one non-official source URL.

### New brand files
- **TikTok** – black / cyan / red / white (`010101`, `25F4EE`, `FE2C55`, `FFFFFF`)
- **Douyin** – same core palette as TikTok (`000000`, `FE2C55`, `25F4EE`, `FFFFFF`)
- **Kuaishou** – orange `FF6600`
- **Weibo** – red `E6162D`, red-orange `FA3C2E`
- **QQ** – sky blue `12B7F5`, yellow `FEBF1B`, red `E32B10`
- **X** (formerly Twitter) – monochrome `000000` / `FFFFFF`
- **Qzone** – yellow `FECE00`
- **Threads** – monochrome `000000` / `FFFFFF` (Meta brand resources linked)
- **Xiaohongshu** – torch red `FF2442`
- **Josh** – pink-magenta `F0286F`
- **Microsoft Teams** – purple-blue palette `6264A7`, `464EB8`, `7B83EB`, `505AC9`
- **Baidu Tieba** – palatinate blue `2529D8`
- **imo** – sky blue `1BB6EC`
- **Likee** – pink-red `FF5C8D`
- **Picsart** – magenta-purple `C209C1`
- **Vevo** – black / white core (brand.vevo.com/color linked)

### Other changes
- `telegram.json`: removed brandfetch.com `sourceUrl` since only official brand-related sources are allowed (set to `null`).

The already-present brands from the request list (Facebook, YouTube, WhatsApp, Instagram, WeChat, Messenger, LinkedIn, Snapchat, Reddit, Pinterest, Quora, Viber, Discord, Twitch, LINE, Tumblr) already conform to the schema with official source URLs and were left unchanged.

## Test plan
- [x] All 17 JSON files parse as valid JSON
- [x] Full build pipeline (`npx ts-node src/main.ts`) runs without Joi validation errors for any brand
- [x] All hex color values conform to the schema's 3/4/6/8-character pattern
- [x] No duplicate slugs introduced (`x.json` distinct from existing `twitter.json`; `teams.json` distinct from `teamspeak.json`/`microsoft-*`)
